### PR TITLE
mark module as complete

### DIFF
--- a/src/Module/components/ModuleDefault.vue
+++ b/src/Module/components/ModuleDefault.vue
@@ -157,7 +157,7 @@ export default defineComponent({
         }
       ]
     };
-    const { adkData } = getModAdk(
+    const { adkData, adkIndex } = getModAdk(
       props,
       ctx.emit,
       'Practice',
@@ -215,6 +215,14 @@ export default defineComponent({
         lengthPractice.value += 1;
       }
       // console.log(adkData.value.practiceLog);
+
+      // TODO: get the actual expected minimum log time. Maybe `adkData.defaultActivity.endEarlyActivity * 60`?
+      if (finalValueLog.value > 100) { 
+        adkData.value.update(() => ({
+          isComplete: true,
+          adkIndex: adkIndex
+        }))
+      }
       return new Promise((resolve, reject) => {
         studentDocument.value.update();
         resolve(true);

--- a/src/Module/types.ts
+++ b/src/Module/types.ts
@@ -2,6 +2,6 @@ export default interface MongoDoc {
   data: {
     adks: Record<string, any>[];
   };
-  update: () => Promise<any>;
+  update: (shouldMarkAsComplete?:any) => Promise<any>;
   changeStream: any;
 }


### PR DESCRIPTION
I have not been able to test this module, so I'm just taking my best guess as to how we want to evaluate when users have completed it. In this case, I assume that when we `logMinutes()`, we can check that the user has logged more than the minimum number of minutes needed. I've left a placeholder amount (100) for now, but that will likely need to be set on a per-program basis.

# TODO
- [ ] test module (module is incomplete at the time of this PR)
- [ ] bump up npm package version